### PR TITLE
Fix syntax error in pair of references in paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -111,7 +111,7 @@ So far the code has been used to study a range of fundamental physics problems:
   
 - Superradiance with self-interacting vector field [@Clough:2022ygm] and with spatially varying mass [@Wang:2022hra]
   
-- BH mergers in wave dark matter environments [@Bamber:2022pbs,@Aurrekoetxea:2023jwk]
+- BH mergers in wave dark matter environments [@Bamber:2022pbs;@Aurrekoetxea:2023jwk]
 
 
 # Acknowledgements


### PR DESCRIPTION
I just spotted an error in my previous PR #24, relevant to the [JOSS review](https://github.com/GRTLCollaboration/GRDzhadzha/pull/openjournals/joss-reviews#5956): the citations should be separated by `;`, not `,`. Sorry for dragging this out!