### PR TITLE
Feature: add ability to specify excision zones in KerrSchild class

### DIFF
--- a/Source/Background/KerrSchild.hpp
+++ b/Source/Background/KerrSchild.hpp
@@ -244,7 +244,7 @@ class KerrSchild
   public:
     // used to decide when to excise - ie when within the horizon of the BH
     // note that this is not templated over data_t
-    bool check_if_excised(const Coordinates<double> &coords) const
+    bool check_if_excised(const Coordinates<double> &coords, const double innerH_buffer = 1.05, const double outerH_buffer = 0.9) const
     {
         // black hole params - mass M and spin a
         const double M = m_params.mass;
@@ -270,7 +270,7 @@ class KerrSchild
 
         bool is_excised = false;
         // value less than 1 indicates we are within the horizon
-        if (outer_horizon < 0.9 || inner_horizon < 1.05)
+        if (outer_horizon < outerH_buffer || inner_horizon < innerH_buffer)
         {
             is_excised = true;
         }


### PR DESCRIPTION
This functionality was discussed with @KAClough and it adds the ability for users to specify the excision zones in the KerrSchild::check_if_excised method. The default values are the original hard-coded values, so this should not conflict with any existing code. I needed to do function overloading to include this code in my own project, but Katy suggested I just create a PR here.